### PR TITLE
fix(logging): Allow JSON printing in logging

### DIFF
--- a/scripts/batch.py
+++ b/scripts/batch.py
@@ -63,7 +63,8 @@ from survey_assist_utils.api_token.jwt_utils import (
 from survey_assist_utils.cloud_store.gcs_utils import download_from_gcs, upload_to_gcs
 
 WAIT_TIMER = 0.5  # seconds to wait between requests to avoid rate limiting
-UPLOAD_ROWS = 5 # upload every 5 rows
+UPLOAD_ROWS = 5  # upload every 5 rows
+
 
 # Load the config:
 def load_config(config_path):
@@ -96,7 +97,9 @@ def process_row(row, secret_code, app_config):
     Returns:
     dict: The response JSON with additional information.
     """
-    base_url = os.getenv("API_GATEWAY", "http://127.0.0.1:5000") + "/survey-assist/classify"
+    base_url = (
+        os.getenv("API_GATEWAY", "http://127.0.0.1:5000") + "/survey-assist/classify"
+    )
     unique_id = row[app_config["column_names"]["payload_unique_id"]]
     job_title = row[app_config["column_names"]["payload_job_title"]]
     job_description = row[app_config["column_names"]["payload_job_description"]]
@@ -183,9 +186,7 @@ def process_test_set(
         output_filepath = output_filepath.rstrip("/")  # Remove trailing slash
         output_filepath += "/analysis_outputs/"
         output_filepath += time.strftime("%Y%m%d_%H%M%S") + "_output.json"
-        logging.info(
-            "Output will be uploaded to GCS bucket: %s", output_filepath
-        )
+        logging.info("Output will be uploaded to GCS bucket: %s", output_filepath)
     else:
         local_output_path = output_filepath
 
@@ -204,13 +205,15 @@ def process_test_set(
                     "Uploading intermediate results to GCS bucket: %s, i: %s tot:%s",
                     output_filepath,
                     i,
-                    total_rows
+                    total_rows,
                 )
 
                 upload_to_gcs(local_output_path, output_filepath)
 
             percent_complete = round(((i + 1) / total_rows) * 100, 2)
-            logging.info("Processed row %d of %d (%.2f%%)", i + 1, total_rows, percent_complete)
+            logging.info(
+                "Processed row %d of %d (%.2f%%)", i + 1, total_rows, percent_complete
+            )
             time.sleep(WAIT_TIMER)  # Wait between requests to avoid rate limiting
 
         # Remove the last comma and close the array

--- a/src/survey_assist_utils/cloud_store/gcs_utils.py
+++ b/src/survey_assist_utils/cloud_store/gcs_utils.py
@@ -28,5 +28,6 @@ def download_from_gcs(gcs_uri, local_path):
     bucket = client.bucket(bucket_name)
     blob = bucket.blob(blob_path)
     blob.download_to_filename(local_path)
-    logging.info("Downloaded GCS file gs://%s/%s to %s", bucket_name, blob_path, local_path)
-
+    logging.info(
+        "Downloaded GCS file gs://%s/%s to %s", bucket_name, blob_path, local_path
+    )

--- a/src/survey_assist_utils/logging/logging_utils.py
+++ b/src/survey_assist_utils/logging/logging_utils.py
@@ -167,7 +167,11 @@ class SurveyAssistLogger:
 
         try:
             # If JSON_DEBUG is set, pretty print the context
-            return json.dumps(context, cls=EnhancedJSONEncoder, indent=2 if os.getenv("JSON_DEBUG") else None)
+            return json.dumps(
+                context,
+                cls=EnhancedJSONEncoder,
+                indent=2 if os.getenv("JSON_DEBUG") else None,
+            )
         except TypeError as e:
             context["serialization_error"] = str(e)
             return json.dumps(context)

--- a/src/survey_assist_utils/logging/logging_utils.py
+++ b/src/survey_assist_utils/logging/logging_utils.py
@@ -7,6 +7,7 @@ import inspect
 import json
 import logging
 import os
+from datetime import datetime
 from typing import Any, Union
 
 # Import cloud logging at module level
@@ -33,6 +34,13 @@ MODULE_NAME_TRUNCATE_LENGTH = 15
 def _get_cloud_logging():
     """Get the cloud logging module if available."""
     return gcp_logging
+
+
+class EnhancedJSONEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, datetime):
+            return obj.isoformat()
+        return super().default(obj)
 
 
 class SurveyAssistLogger:
@@ -154,9 +162,15 @@ class SurveyAssistLogger:
             "message": message,
             "module": module_name,
             "func": func_name,
-            **kwargs,
         }
-        return json.dumps(context)
+        context.update(kwargs)
+
+        try:
+            # If JSON_DEBUG is set, pretty print the context
+            return json.dumps(context, cls=EnhancedJSONEncoder, indent=2 if os.getenv("JSON_DEBUG") else None)
+        except TypeError as e:
+            context["serialization_error"] = str(e)
+            return json.dumps(context)
 
     def debug(self, message: str, **kwargs) -> None:
         """Log a debug message."""


### PR DESCRIPTION
# 📌 JSON Logging Fix

## ✨ Summary

Datetime objects were not being catered for in the logging which leads to bad logging when the logger is used to output a structure that includes this data.

## 📜 Changes Introduced

Added EnhancedJSONEncoder to cater for logging JSON that includes datetime, the implementation optionally pretty prints JSON structures if an environment variable JSON_DEBUG is set.

A couple of minor tidy ups for linting

- [x] bug fix (fix:)
- [x] Updates to tests and/or documentation
- n/a Terraform changes (if applicable)

## ✅ Checklist

> **Please confirm you've completed these checks before requesting a review.**

- [x] Code is formatted using **Black**
- [x] Imports are sorted using **isort**
- [x] Code passes linting with **Ruff**, **Pylint**, and **Mypy**
- [x] Security checks pass using **Bandit**
- [x] API and Unit tests are written and pass using **pytest**
- n/a Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [x] DocStrings follow Google-style and are added as per Pylint recommendations
- [x] Documentation has been updated if needed

## 🔍 How to Test

Visual code inspection should suffice. Alternatively add a log for a JSON structure and check that the logging using the custom logger looks as expected (JSON should not be escaped).