### PR TITLE
Sa239 original prompt evaluation

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3481,6 +3481,62 @@ files = [
 tests = ["pytest"]
 
 [[package]]
+name = "pyarrow"
+version = "21.0.0"
+description = "Python library for Apache Arrow"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "pyarrow-21.0.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:e563271e2c5ff4d4a4cbeb2c83d5cf0d4938b891518e676025f7268c6fe5fe26"},
+    {file = "pyarrow-21.0.0-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:fee33b0ca46f4c85443d6c450357101e47d53e6c3f008d658c27a2d020d44c79"},
+    {file = "pyarrow-21.0.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:7be45519b830f7c24b21d630a31d48bcebfd5d4d7f9d3bdb49da9cdf6d764edb"},
+    {file = "pyarrow-21.0.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:26bfd95f6bff443ceae63c65dc7e048670b7e98bc892210acba7e4995d3d4b51"},
+    {file = "pyarrow-21.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:bd04ec08f7f8bd113c55868bd3fc442a9db67c27af098c5f814a3091e71cc61a"},
+    {file = "pyarrow-21.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:9b0b14b49ac10654332a805aedfc0147fb3469cbf8ea951b3d040dab12372594"},
+    {file = "pyarrow-21.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:9d9f8bcb4c3be7738add259738abdeddc363de1b80e3310e04067aa1ca596634"},
+    {file = "pyarrow-21.0.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:c077f48aab61738c237802836fc3844f85409a46015635198761b0d6a688f87b"},
+    {file = "pyarrow-21.0.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:689f448066781856237eca8d1975b98cace19b8dd2ab6145bf49475478bcaa10"},
+    {file = "pyarrow-21.0.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:479ee41399fcddc46159a551705b89c05f11e8b8cb8e968f7fec64f62d91985e"},
+    {file = "pyarrow-21.0.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:40ebfcb54a4f11bcde86bc586cbd0272bac0d516cfa539c799c2453768477569"},
+    {file = "pyarrow-21.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8d58d8497814274d3d20214fbb24abcad2f7e351474357d552a8d53bce70c70e"},
+    {file = "pyarrow-21.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:585e7224f21124dd57836b1530ac8f2df2afc43c861d7bf3d58a4870c42ae36c"},
+    {file = "pyarrow-21.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:555ca6935b2cbca2c0e932bedd853e9bc523098c39636de9ad4693b5b1df86d6"},
+    {file = "pyarrow-21.0.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:3a302f0e0963db37e0a24a70c56cf91a4faa0bca51c23812279ca2e23481fccd"},
+    {file = "pyarrow-21.0.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:b6b27cf01e243871390474a211a7922bfbe3bda21e39bc9160daf0da3fe48876"},
+    {file = "pyarrow-21.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:e72a8ec6b868e258a2cd2672d91f2860ad532d590ce94cdf7d5e7ec674ccf03d"},
+    {file = "pyarrow-21.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:b7ae0bbdc8c6674259b25bef5d2a1d6af5d39d7200c819cf99e07f7dfef1c51e"},
+    {file = "pyarrow-21.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:58c30a1729f82d201627c173d91bd431db88ea74dcaa3885855bc6203e433b82"},
+    {file = "pyarrow-21.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:072116f65604b822a7f22945a7a6e581cfa28e3454fdcc6939d4ff6090126623"},
+    {file = "pyarrow-21.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:cf56ec8b0a5c8c9d7021d6fd754e688104f9ebebf1bf4449613c9531f5346a18"},
+    {file = "pyarrow-21.0.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:e99310a4ebd4479bcd1964dff9e14af33746300cb014aa4a3781738ac63baf4a"},
+    {file = "pyarrow-21.0.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:d2fe8e7f3ce329a71b7ddd7498b3cfac0eeb200c2789bd840234f0dc271a8efe"},
+    {file = "pyarrow-21.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:f522e5709379d72fb3da7785aa489ff0bb87448a9dc5a75f45763a795a089ebd"},
+    {file = "pyarrow-21.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:69cbbdf0631396e9925e048cfa5bce4e8c3d3b41562bbd70c685a8eb53a91e61"},
+    {file = "pyarrow-21.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:731c7022587006b755d0bdb27626a1a3bb004bb56b11fb30d98b6c1b4718579d"},
+    {file = "pyarrow-21.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dc56bc708f2d8ac71bd1dcb927e458c93cec10b98eb4120206a4091db7b67b99"},
+    {file = "pyarrow-21.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:186aa00bca62139f75b7de8420f745f2af12941595bbbfa7ed3870ff63e25636"},
+    {file = "pyarrow-21.0.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:a7a102574faa3f421141a64c10216e078df467ab9576684d5cd696952546e2da"},
+    {file = "pyarrow-21.0.0-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:1e005378c4a2c6db3ada3ad4c217b381f6c886f0a80d6a316fe586b90f77efd7"},
+    {file = "pyarrow-21.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:65f8e85f79031449ec8706b74504a316805217b35b6099155dd7e227eef0d4b6"},
+    {file = "pyarrow-21.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:3a81486adc665c7eb1a2bde0224cfca6ceaba344a82a971ef059678417880eb8"},
+    {file = "pyarrow-21.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fc0d2f88b81dcf3ccf9a6ae17f89183762c8a94a5bdcfa09e05cfe413acf0503"},
+    {file = "pyarrow-21.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:6299449adf89df38537837487a4f8d3bd91ec94354fdd2a7d30bc11c48ef6e79"},
+    {file = "pyarrow-21.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:222c39e2c70113543982c6b34f3077962b44fca38c0bd9e68bb6781534425c10"},
+    {file = "pyarrow-21.0.0-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:a7f6524e3747e35f80744537c78e7302cd41deee8baa668d56d55f77d9c464b3"},
+    {file = "pyarrow-21.0.0-cp39-cp39-macosx_12_0_x86_64.whl", hash = "sha256:203003786c9fd253ebcafa44b03c06983c9c8d06c3145e37f1b76a1f317aeae1"},
+    {file = "pyarrow-21.0.0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:3b4d97e297741796fead24867a8dabf86c87e4584ccc03167e4a811f50fdf74d"},
+    {file = "pyarrow-21.0.0-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:898afce396b80fdda05e3086b4256f8677c671f7b1d27a6976fa011d3fd0a86e"},
+    {file = "pyarrow-21.0.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:067c66ca29aaedae08218569a114e413b26e742171f526e828e1064fcdec13f4"},
+    {file = "pyarrow-21.0.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:0c4e75d13eb76295a49e0ea056eb18dbd87d81450bfeb8afa19a7e5a75ae2ad7"},
+    {file = "pyarrow-21.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:cdc4c17afda4dab2a9c0b79148a43a7f4e1094916b3e18d8975bfd6d6d52241f"},
+    {file = "pyarrow-21.0.0.tar.gz", hash = "sha256:5051f2dccf0e283ff56335760cbc8622cf52264d67e359d5569541ac11b6d5bc"},
+]
+
+[package.extras]
+test = ["cffi", "hypothesis", "pandas", "pytest", "pytz"]
+
+[[package]]
 name = "pyasn1"
 version = "0.6.1"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
@@ -5021,4 +5077,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "ad58deae7186e335400a4355d92e566099fe6085d7ad04366b7eebfd17a7d7d8"
+content-hash = "202ae37f75877c2f8f8cf5056f6da0e77f7ed83cbdd6847b43be53720f025c3b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ fsspec = "^2025.3.2"
 gcsfs = "^2025.3.2"
 langchain-google-vertexai = "0.0.1"
 langchain = "0.1.0"
+pyarrow = "^21.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mkdocs-material = "^9.6.7"

--- a/scripts/eval_metrics_original_prompt.py
+++ b/scripts/eval_metrics_original_prompt.py
@@ -1,0 +1,102 @@
+import pandas as pd
+import numpy as np
+import re
+from collections import namedtuple
+from survey_assist_utils.evaluation.coder_alignment import ColumnConfig, LabelAccuracy
+
+def parse_sic_candidates(candidates_str):
+    """Parse SIC candidates from SicCandidate string format"""
+    if pd.isna(candidates_str) or candidates_str == "" or str(candidates_str).lower() == "nan":
+        return []
+
+    # Create named tuple type
+    SicCandidate = namedtuple('SicCandidate', ['sic_code', 'sic_descriptive', 'likelihood'])
+
+    try:
+        # Extract all RagCandidate entries using regex
+        pattern = r"SicCandidate\(sic_code='([^']+)', sic_descriptive='([^']+)', likelihood=([0-9.]+)\)"
+        matches = re.findall(pattern, str(candidates_str))
+
+        candidates = []
+        for match in matches:
+            candidate = SicCandidate(
+                sic_code=match[0],
+                sic_descriptive=match[1], 
+                likelihood=float(match[2])
+            )
+            candidates.append(candidate)
+
+        return candidates
+    except Exception as e:
+        return []
+
+
+def parse_clerical_code(candidates_str: str):
+    if pd.isna(candidates_str) or candidates_str == "" or str(candidates_str).lower() == "nan":
+        return []
+
+    try:
+        # Extract all RagCandidate entries using regex
+        pattern = r"([0-9]+x*X*)"
+        matches = re.findall(pattern, str(candidates_str))
+
+        return matches
+    except Exception as e:
+        raise
+
+# 1. Load your prepared data
+# my_dataframe = pd.read_pickle("../data/one_prompt_rand100_stg2_2025_08_11_13.gz")
+my_dataframe = pd.read_csv("../data/one_prompt_rand100_stg2_2025_08_11_13.csv")
+
+# 2. Get clerically coded data
+cc_data = pd.read_csv("../data/tlfs_2k_eval_set.csv")
+
+# 3. Merge datasets
+merged_data = my_dataframe.merge(cc_data[['unique_id', 'Not_Codeable',
+       'Four_Or_More', 'SIC_Division', 'num_answers', 'All_Clerical_codes',
+       'Match_5_digits', 'Match_3_digits', 'Match_2_digits', 'Unambiguous']], left_on="unique_id", right_on="unique_id", how = "left")
+
+# 4. Parse sic_candidates from LLM output
+merged_data['sic_candidate_list'] = merged_data['sic_candidates'].apply(parse_sic_candidates)
+
+# 5. Unpack sic_candidates into new individual columns
+for i in range(0,10):
+    merged_data['sic_candidate_' + str(i+1)] = merged_data['sic_candidate_list'].apply(lambda x: x[i].sic_code if len(x)>i else '')
+
+for i in range(0,10):
+    merged_data['sic_candidate_score_' + str(i+1)] = 0.5
+
+# 5. Unpack CC labels
+merged_data['cc_list'] = merged_data['All_Clerical_codes'].apply(parse_clerical_code)
+
+for i in range(0,5):
+    merged_data['cc_candidate_' + str(i+1)] = merged_data['cc_list'].apply(lambda x: x[i] if len(x)>i else '')
+
+# 7. Define the configuration for the test
+# This example compares the top 3 model suggestions against 2 human-coded columns
+col_config = ColumnConfig(
+    model_label_cols=["sic_candidate_1", "sic_candidate_2"],
+    model_score_cols=["sic_candidate_score_1", "sic_candidate_score_2"],
+    clerical_label_cols=["cc_candidate_1", "cc_candidate_2"],
+    id_col="unique_id",
+    filter_unambiguous=True  # Only analyze unambiguous records in this case
+)
+
+# 3. Initialise the analyser with the DataFrame and config
+analyzer = LabelAccuracy(df=my_dataframe, column_config=col_config)
+
+# 4. Run the desired analysis
+# Get detailed accuracy stats for full 5-digit matches
+accuracy_stats = analyzer.get_accuracy(match_type="2-dig", extended=True) #match_type can be "2-digit"
+
+# Calculate the average suggestion quality
+# jaccard_score = analyzer.get_jaccard_similarity()
+
+# Generate a confusion matrix heatmap
+# analyzer.plot_confusion_heatmap(
+#     human_code_col="CC_1",
+#     llm_code_col="SA_1"
+# )
+
+print(f"Accuracy Stats: {accuracy_stats}")
+# print(f"Average Jaccard Score: {jaccard_score:.4f}")

--- a/scripts/one_prompt_evaluation.py
+++ b/scripts/one_prompt_evaluation.py
@@ -20,25 +20,42 @@ def parse_args():
         type=str,
         help="relative path to the CSV file containing clerically coded data",
     )
-    # parser.add_argument(
-    #     "output_folder",
-    #     type=str,
-    #     help="relative path to the output folder location (will be created if it doesn't exist)",
-    # )
+    parser.add_argument(
+        "--prepared_data_columns",
+        "-pcol",
+        type=list,
+        default=['unique_id', 'sic_section', 'sic2007_employee',
+        'sic2007_self_employed', 'sic_ind1', 'sic_ind2', 'sic_ind3',
+        'sic_ind_code_flag', 'soc2020_job_title', 'soc2020_job_description',
+        'sic_ind_occ1', 'sic_ind_occ2', 'sic_ind_occ3', 'sic_ind_occ_flag',
+        'semantic_search_results', 'final_sic_code', 'sic_candidates'],
+        help="""A list of all columns from the prepared data to be included for
+        the evaluation (optional, default: list[str])""",
+    )
+    parser.add_argument(
+        "--clerical_data_columns",
+        "-ccol",
+        type=list,
+        default=['unique_id', 'Not_Codeable', 'Four_Or_More', 'SIC_Division',
+        'num_answers', 'All_Clerical_codes', 'Match_5_digits',
+        'Match_3_digits', 'Match_2_digits', 'Unambiguous'],
+        help="""A list of all columns from the clerically coded data to be
+        included for the evaluation (optional, default: list[str])""",
+    )
+    parser.add_argument(
+        "--test_configuration",
+        "-t",
+        type=str,
+        default="MM",
+        help="""test configuration; specify the type one-to-one, one-to-many,
+        many-to-one, many-to-many , select `OO`, `OM`, `MO`, or `MM`. Defaults to `MM`""",
+    )
     # parser.add_argument(
     #     "--output_shortname",
     #     "-n",
     #     type=str,
     #     default="STG1",
     #     help="output filename prefix for easy identification (optional, default: STG1)",
-    # )
-    # parser.add_argument(
-    #     "--batch_size",
-    #     "-b",
-    #     type=int,
-    #     default=200,
-    #     help="save the output every X rows, as a checkpoint that can be used to restart the "
-    #     "processing job if needed (optional, default: 200)",
     # )
     # parser.add_argument(
     #     "--restart",
@@ -88,72 +105,67 @@ def parse_clerical_code(candidates_str: str):
     except Exception as e:
         raise
 
-
+# Get prepared data
 def get_prepared_data(ss_df_path):
     return pd.read_parquet(ss_df_path)
 
+# Get clerically coded data
 def get_cc_data(cc_df_path):
-    return pd.read_csv(cc_df_path)
+    return pd.read_csv(cc_df_path) # Double check if that is CSV or parquet
 
-# 1. Load your prepared data
-# my_dataframe = pd.read_parquet("data/stage_2_one_prompt_20.parquet")
-# my_dataframe = pd.read_parquet("data/stage_2_one_prompt_2k.parquet")
+# Merge two datasets, preparing for the evaluation
+def merge_datasets(prepared_data, cc_data, prepared_data_columns, clerical_data_columns):
+    return prepared_data[prepared_data_columns].merge(cc_data[clerical_data_columns], left_on="unique_id", right_on="unique_id", how = "left")
 
-# # 2. Get clerically coded data
-# cc_data = pd.read_csv("data/tlfs_2k_eval_set.csv")
+# Unpack sic_candidates into new individual columns
+def sic_candidates_individual(merged_data):
+    for i in range(0,10):
+        merged_data['sic_candidate_' + str(i+1)] = merged_data['sic_candidate_list'].apply(lambda x: x[i].sic_code if len(x)>i else '')
 
-# # 3. Merge datasets
-# merged_data = my_dataframe[['unique_id', 'sic_section', 'sic2007_employee', 'sic2007_self_employed',
-#     'sic_ind1', 'sic_ind2', 'sic_ind3', 'sic_ind_code_flag',
-#     'soc2020_job_title', 'soc2020_job_description', 'sic_ind_occ1',
-#     'sic_ind_occ2', 'sic_ind_occ3', 'sic_ind_occ_flag',
-#     'semantic_search_results', 'final_sic_code', 'sic_candidates']].merge(cc_data[['unique_id', 'Not_Codeable',
-#     'Four_Or_More', 'SIC_Division', 'num_answers', 'All_Clerical_codes',
-#     'Match_5_digits', 'Match_3_digits', 'Match_2_digits', 'Unambiguous']], left_on="unique_id", right_on="unique_id", how = "left")
+    for i in range(0,10):
+        merged_data['sic_candidate_score_' + str(i+1)] = 0.5
 
-# # 4. Parse sic_candidates from LLM output
-# merged_data['sic_candidate_list'] = merged_data['sic_candidates'].apply(parse_sic_candidates)
+# Unpack CC labels
+def unpack_cc(merged_data):
+    merged_data['cc_list'] = merged_data['All_Clerical_codes'].apply(parse_clerical_code)
 
-# # 5. Unpack sic_candidates into new individual columns
-# for i in range(0,10):
-#     merged_data['sic_candidate_' + str(i+1)] = merged_data['sic_candidate_list'].apply(lambda x: x[i].sic_code if len(x)>i else '')
+    for i in range(0,5):
+        merged_data['cc_candidate_' + str(i+1)] = merged_data['cc_list'].apply(lambda x: x[i] if len(x)>i else '')
 
-# for i in range(0,10):
-#     merged_data['sic_candidate_score_' + str(i+1)] = 0.5
+def test_configuration(compare): # Future: parse how many columns form LLM compare to how many columns prepared by clerically coded.
+    # This example compares the top 3 model suggestions against 2 human-coded columns
+    # Add MO, OO
+    # should we allow comparing different sets, e.g. 3v3, 5v2 (currently we do 3v2)
+    """Choose from OO, MM, OM, MO, where O stands for One, M stands for Many.
+    First initial for clerically coded, second initial for LLM prepared data.
 
-# # 6. Unpack CC labels
-# merged_data['cc_list'] = merged_data['All_Clerical_codes'].apply(parse_clerical_code)
+    Args:
+        compare (str, optional): _description_. Defaults to "MM".
 
-# for i in range(0,5):
-#     merged_data['cc_candidate_' + str(i+1)] = merged_data['cc_list'].apply(lambda x: x[i] if len(x)>i else '')
-
-# # 7. Define the configuration for the test
-# # This example compares the top 3 model suggestions against 2 human-coded columns
-# col_config = ColumnConfig(
-#     model_label_cols=["sic_candidate_1", "sic_candidate_2"],
-#     model_score_cols=["sic_candidate_score_1", "sic_candidate_score_2"],
-#     clerical_label_cols=["cc_candidate_1", "cc_candidate_2"],
-#     id_col="unique_id",
-#     filter_unambiguous=True  # Only analyze unambiguous records in this case
-# )
-
-# # 3. Initialise the analyser with the DataFrame and config
-# analyzer = LabelAccuracy(df=merged_data, column_config=col_config)
-
-# # 4. Run the desired analysis
-# # Get detailed accuracy stats for full 5-digit matches
-# accuracy_stats = analyzer.get_accuracy(match_type="2-digit", extended=True) #match_type can be "2-digit"
+    Returns:
+        _type_: _description_
+    """
+    if compare == "MM":
+        col_config = ColumnConfig(
+            clerical_label_cols=["cc_candidate_1", "cc_candidate_2"],
+            model_label_cols=["sic_candidate_1", "sic_candidate_2"],
+            model_score_cols=["sic_candidate_score_1", "sic_candidate_score_2"],
+            id_col="unique_id",
+            filter_unambiguous=True  # Only analyze unambiguous records in this case
+        )
+    elif compare == "OM":
+        col_config = ColumnConfig(
+            clerical_label_cols=["cc_candidate_1"],
+            model_label_cols=["sic_candidate_1", "sic_candidate_2"],
+            model_score_cols=["sic_candidate_score_1", "sic_candidate_score_2"],
+            id_col="unique_id",
+            filter_unambiguous=True  # Only analyze unambiguous records in this case
+        )
+    return col_config
 
 # # Calculate the average suggestion quality
 # jaccard_score = analyzer.get_jaccard_similarity()
-
-# # Generate a confusion matrix heatmap
-# # analyzer.plot_confusion_heatmap(
-# #     human_code_col="CC_1",
-# #     llm_code_col="SA_1"
-# # )
-
-# print(f"Accuracy Stats: {accuracy_stats}")
+ 
 # print(f"Average Jaccard Score: {jaccard_score:.4f}")
 
 
@@ -161,6 +173,22 @@ def get_cc_data(cc_df_path):
 if __name__ == "__main__":
     args = parse_args()
 
+    # Read the data
     prepared_data = get_prepared_data(args.prepared_data)
     cc_data = get_cc_data(args.cc_data)
-    print(prepared_data)
+    
+    # Merge two datasets
+    merged_data = merge_datasets(prepared_data, cc_data, args.prepared_data_columns, args.clerical_data_columns)
+    
+    # Parse sic_candidates from LLM output
+    merged_data['sic_candidate_list'] = merged_data['sic_candidates'].apply(parse_sic_candidates)
+    
+    sic_candidates_individual(merged_data)
+    unpack_cc(merged_data)
+    col_config = test_configuration(args.test_configuration)
+    # Initialise the analyser with the DataFrame and config
+    analyzer = LabelAccuracy(df=merged_data, column_config=col_config)
+    # Run the desired analysis
+    # Get detailed accuracy stats for full 5-digit matches
+    accuracy_stats = analyzer.get_accuracy(match_type="2-digit", extended=True) #match_type can be "2-digit"
+    print(f"Accuracy Stats: {accuracy_stats}")

--- a/scripts/one_prompt_evaluation.py
+++ b/scripts/one_prompt_evaluation.py
@@ -1,0 +1,104 @@
+import pandas as pd
+import numpy as np
+import re
+from collections import namedtuple
+from survey_assist_utils.evaluation.coder_alignment import ColumnConfig, LabelAccuracy
+
+def parse_sic_candidates(candidates_str):
+    """Parse SIC candidates from SicCandidate string format"""
+    candidates_array = np.array(candidates_str)
+    if (pd.isna(candidates_array)).all() or str(candidates_array) == "" or str(candidates_array).lower() == "nan":
+        return []
+
+    # Create named tuple type
+    SicCandidate = namedtuple('SicCandidate', ['likelihood', 'sic_code'])
+    
+
+    try:
+        # Extract all RagCandidate entries using regex
+        pattern = r"\{'likelihood':\s*[\d\.]+,\s*'sic_code':\s*'[\d]+'\}"
+
+        candidates = []
+        for item in candidates_array:
+            likelihood = item['likelihood']
+            sic_code = item['sic_code']
+            candidates.append(SicCandidate(likelihood, sic_code))
+
+        return candidates
+    except Exception as e:
+        return []
+
+
+def parse_clerical_code(candidates_str: str):
+    if pd.isna(candidates_str) or candidates_str == "" or str(candidates_str).lower() == "nan":
+        return []
+
+    try:
+        # Extract all RagCandidate entries using regex
+        pattern = r"([0-9]+x*X*)"
+        matches = re.findall(pattern, str(candidates_str))
+
+        return matches
+    except Exception as e:
+        raise
+
+# 1. Load your prepared data
+# my_dataframe = pd.read_parquet("data/stage_2_one_prompt_20.parquet")
+my_dataframe = pd.read_parquet("data/stage_2_one_prompt_2k.parquet")
+
+# 2. Get clerically coded data
+cc_data = pd.read_csv("data/tlfs_2k_eval_set.csv")
+
+# 3. Merge datasets
+merged_data = my_dataframe[['unique_id', 'sic_section', 'sic2007_employee', 'sic2007_self_employed',
+       'sic_ind1', 'sic_ind2', 'sic_ind3', 'sic_ind_code_flag',
+       'soc2020_job_title', 'soc2020_job_description', 'sic_ind_occ1',
+       'sic_ind_occ2', 'sic_ind_occ3', 'sic_ind_occ_flag',
+       'semantic_search_results', 'final_sic_code', 'sic_candidates']].merge(cc_data[['unique_id', 'Not_Codeable',
+       'Four_Or_More', 'SIC_Division', 'num_answers', 'All_Clerical_codes',
+       'Match_5_digits', 'Match_3_digits', 'Match_2_digits', 'Unambiguous']], left_on="unique_id", right_on="unique_id", how = "left")
+
+# 4. Parse sic_candidates from LLM output
+merged_data['sic_candidate_list'] = merged_data['sic_candidates'].apply(parse_sic_candidates)
+
+# 5. Unpack sic_candidates into new individual columns
+for i in range(0,10):
+    merged_data['sic_candidate_' + str(i+1)] = merged_data['sic_candidate_list'].apply(lambda x: x[i].sic_code if len(x)>i else '')
+
+for i in range(0,10):
+    merged_data['sic_candidate_score_' + str(i+1)] = 0.5
+
+# 6. Unpack CC labels
+merged_data['cc_list'] = merged_data['All_Clerical_codes'].apply(parse_clerical_code)
+
+for i in range(0,5):
+    merged_data['cc_candidate_' + str(i+1)] = merged_data['cc_list'].apply(lambda x: x[i] if len(x)>i else '')
+
+# 7. Define the configuration for the test
+# This example compares the top 3 model suggestions against 2 human-coded columns
+col_config = ColumnConfig(
+    model_label_cols=["sic_candidate_1", "sic_candidate_2"],
+    model_score_cols=["sic_candidate_score_1", "sic_candidate_score_2"],
+    clerical_label_cols=["cc_candidate_1", "cc_candidate_2"],
+    id_col="unique_id",
+    filter_unambiguous=True  # Only analyze unambiguous records in this case
+)
+
+# 3. Initialise the analyser with the DataFrame and config
+analyzer = LabelAccuracy(df=merged_data, column_config=col_config)
+
+# 4. Run the desired analysis
+# Get detailed accuracy stats for full 5-digit matches
+accuracy_stats = analyzer.get_accuracy(match_type="2-digit", extended=True) #match_type can be "2-digit"
+
+# Calculate the average suggestion quality
+jaccard_score = analyzer.get_jaccard_similarity()
+
+# Generate a confusion matrix heatmap
+# analyzer.plot_confusion_heatmap(
+#     human_code_col="CC_1",
+#     llm_code_col="SA_1"
+# )
+
+print(f"Accuracy Stats: {accuracy_stats}")
+print(f"Average Jaccard Score: {jaccard_score:.4f}")

--- a/scripts/one_prompt_evaluation.py
+++ b/scripts/one_prompt_evaluation.py
@@ -2,7 +2,53 @@ import pandas as pd
 import numpy as np
 import re
 from collections import namedtuple
+from argparse import ArgumentParser as AP
 from survey_assist_utils.evaluation.coder_alignment import ColumnConfig, LabelAccuracy
+
+
+
+############################### MODIFY the parse_args!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!1
+def parse_args():
+    """Parses command line arguments for the script."""
+    parser = AP()
+    parser.add_argument(
+        "prepared_data", type=str,
+        help="relative path to the prepared parquet dataset"
+    )
+    parser.add_argument(
+        "cc_data",
+        type=str,
+        help="relative path to the CSV file containing clerically coded data",
+    )
+    # parser.add_argument(
+    #     "output_folder",
+    #     type=str,
+    #     help="relative path to the output folder location (will be created if it doesn't exist)",
+    # )
+    # parser.add_argument(
+    #     "--output_shortname",
+    #     "-n",
+    #     type=str,
+    #     default="STG1",
+    #     help="output filename prefix for easy identification (optional, default: STG1)",
+    # )
+    # parser.add_argument(
+    #     "--batch_size",
+    #     "-b",
+    #     type=int,
+    #     default=200,
+    #     help="save the output every X rows, as a checkpoint that can be used to restart the "
+    #     "processing job if needed (optional, default: 200)",
+    # )
+    # parser.add_argument(
+    #     "--restart",
+    #     "-r",
+    #     action="store_true",
+    #     default=False,
+    #     help="try to restart a processing job (optional flag)",
+    # )
+    return parser.parse_args()
+
 
 def parse_sic_candidates(candidates_str):
     """Parse SIC candidates from SicCandidate string format"""
@@ -42,63 +88,79 @@ def parse_clerical_code(candidates_str: str):
     except Exception as e:
         raise
 
+
+def get_prepared_data(ss_df_path):
+    return pd.read_parquet(ss_df_path)
+
+def get_cc_data(cc_df_path):
+    return pd.read_csv(cc_df_path)
+
 # 1. Load your prepared data
 # my_dataframe = pd.read_parquet("data/stage_2_one_prompt_20.parquet")
-my_dataframe = pd.read_parquet("data/stage_2_one_prompt_2k.parquet")
+# my_dataframe = pd.read_parquet("data/stage_2_one_prompt_2k.parquet")
 
-# 2. Get clerically coded data
-cc_data = pd.read_csv("data/tlfs_2k_eval_set.csv")
+# # 2. Get clerically coded data
+# cc_data = pd.read_csv("data/tlfs_2k_eval_set.csv")
 
-# 3. Merge datasets
-merged_data = my_dataframe[['unique_id', 'sic_section', 'sic2007_employee', 'sic2007_self_employed',
-       'sic_ind1', 'sic_ind2', 'sic_ind3', 'sic_ind_code_flag',
-       'soc2020_job_title', 'soc2020_job_description', 'sic_ind_occ1',
-       'sic_ind_occ2', 'sic_ind_occ3', 'sic_ind_occ_flag',
-       'semantic_search_results', 'final_sic_code', 'sic_candidates']].merge(cc_data[['unique_id', 'Not_Codeable',
-       'Four_Or_More', 'SIC_Division', 'num_answers', 'All_Clerical_codes',
-       'Match_5_digits', 'Match_3_digits', 'Match_2_digits', 'Unambiguous']], left_on="unique_id", right_on="unique_id", how = "left")
+# # 3. Merge datasets
+# merged_data = my_dataframe[['unique_id', 'sic_section', 'sic2007_employee', 'sic2007_self_employed',
+#     'sic_ind1', 'sic_ind2', 'sic_ind3', 'sic_ind_code_flag',
+#     'soc2020_job_title', 'soc2020_job_description', 'sic_ind_occ1',
+#     'sic_ind_occ2', 'sic_ind_occ3', 'sic_ind_occ_flag',
+#     'semantic_search_results', 'final_sic_code', 'sic_candidates']].merge(cc_data[['unique_id', 'Not_Codeable',
+#     'Four_Or_More', 'SIC_Division', 'num_answers', 'All_Clerical_codes',
+#     'Match_5_digits', 'Match_3_digits', 'Match_2_digits', 'Unambiguous']], left_on="unique_id", right_on="unique_id", how = "left")
 
-# 4. Parse sic_candidates from LLM output
-merged_data['sic_candidate_list'] = merged_data['sic_candidates'].apply(parse_sic_candidates)
+# # 4. Parse sic_candidates from LLM output
+# merged_data['sic_candidate_list'] = merged_data['sic_candidates'].apply(parse_sic_candidates)
 
-# 5. Unpack sic_candidates into new individual columns
-for i in range(0,10):
-    merged_data['sic_candidate_' + str(i+1)] = merged_data['sic_candidate_list'].apply(lambda x: x[i].sic_code if len(x)>i else '')
+# # 5. Unpack sic_candidates into new individual columns
+# for i in range(0,10):
+#     merged_data['sic_candidate_' + str(i+1)] = merged_data['sic_candidate_list'].apply(lambda x: x[i].sic_code if len(x)>i else '')
 
-for i in range(0,10):
-    merged_data['sic_candidate_score_' + str(i+1)] = 0.5
+# for i in range(0,10):
+#     merged_data['sic_candidate_score_' + str(i+1)] = 0.5
 
-# 6. Unpack CC labels
-merged_data['cc_list'] = merged_data['All_Clerical_codes'].apply(parse_clerical_code)
+# # 6. Unpack CC labels
+# merged_data['cc_list'] = merged_data['All_Clerical_codes'].apply(parse_clerical_code)
 
-for i in range(0,5):
-    merged_data['cc_candidate_' + str(i+1)] = merged_data['cc_list'].apply(lambda x: x[i] if len(x)>i else '')
+# for i in range(0,5):
+#     merged_data['cc_candidate_' + str(i+1)] = merged_data['cc_list'].apply(lambda x: x[i] if len(x)>i else '')
 
-# 7. Define the configuration for the test
-# This example compares the top 3 model suggestions against 2 human-coded columns
-col_config = ColumnConfig(
-    model_label_cols=["sic_candidate_1", "sic_candidate_2"],
-    model_score_cols=["sic_candidate_score_1", "sic_candidate_score_2"],
-    clerical_label_cols=["cc_candidate_1", "cc_candidate_2"],
-    id_col="unique_id",
-    filter_unambiguous=True  # Only analyze unambiguous records in this case
-)
-
-# 3. Initialise the analyser with the DataFrame and config
-analyzer = LabelAccuracy(df=merged_data, column_config=col_config)
-
-# 4. Run the desired analysis
-# Get detailed accuracy stats for full 5-digit matches
-accuracy_stats = analyzer.get_accuracy(match_type="2-digit", extended=True) #match_type can be "2-digit"
-
-# Calculate the average suggestion quality
-jaccard_score = analyzer.get_jaccard_similarity()
-
-# Generate a confusion matrix heatmap
-# analyzer.plot_confusion_heatmap(
-#     human_code_col="CC_1",
-#     llm_code_col="SA_1"
+# # 7. Define the configuration for the test
+# # This example compares the top 3 model suggestions against 2 human-coded columns
+# col_config = ColumnConfig(
+#     model_label_cols=["sic_candidate_1", "sic_candidate_2"],
+#     model_score_cols=["sic_candidate_score_1", "sic_candidate_score_2"],
+#     clerical_label_cols=["cc_candidate_1", "cc_candidate_2"],
+#     id_col="unique_id",
+#     filter_unambiguous=True  # Only analyze unambiguous records in this case
 # )
 
-print(f"Accuracy Stats: {accuracy_stats}")
-print(f"Average Jaccard Score: {jaccard_score:.4f}")
+# # 3. Initialise the analyser with the DataFrame and config
+# analyzer = LabelAccuracy(df=merged_data, column_config=col_config)
+
+# # 4. Run the desired analysis
+# # Get detailed accuracy stats for full 5-digit matches
+# accuracy_stats = analyzer.get_accuracy(match_type="2-digit", extended=True) #match_type can be "2-digit"
+
+# # Calculate the average suggestion quality
+# jaccard_score = analyzer.get_jaccard_similarity()
+
+# # Generate a confusion matrix heatmap
+# # analyzer.plot_confusion_heatmap(
+# #     human_code_col="CC_1",
+# #     llm_code_col="SA_1"
+# # )
+
+# print(f"Accuracy Stats: {accuracy_stats}")
+# print(f"Average Jaccard Score: {jaccard_score:.4f}")
+
+
+
+if __name__ == "__main__":
+    args = parse_args()
+
+    prepared_data = get_prepared_data(args.prepared_data)
+    cc_data = get_cc_data(args.cc_data)
+    print(prepared_data)


### PR DESCRIPTION
## ✨ Summary

Introduce a method to evaluate the one prompt approach vs the clerical coder.

## 📜 Changes Introduced

- convert into a script

## ✅ Checklist

> **Please confirm you've completed these checks before requesting a review.**

- [ ] Code is formatted using **Black**
- [ ] Imports are sorted using **isort**
- [ ] Code passes linting with **Ruff**, **Pylint**, and **Mypy**
- [ ] Security checks pass using **Bandit**
- [ ] API and Unit tests are written and pass using **pytest**
- [ ] Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [ ] DocStrings follow Google-style and are added as per Pylint recommendations
- [ ] Documentation has been updated if needed

## 🔍 How to Test

in terminal use:
`python scripts/one_prompt_evaluation.py data/stage_2_one_prompt_2k.parquet data/tlfs_2k_eval_set.csv`,
where:
- `scripts/one_prompt_evaluation.py` is path to the script;
- `data/stage_2_one_prompt_2k.parquet` is path to the data prepared in the previous stage (sic-classification-utils stage_2_get_rag_sic_code);
- `data/tlfs_2k_eval_set.csv` is the path to the data with clerically coded data.
