### PR TITLE
SA-356 split2: code comparison helpers

### DIFF
--- a/src/survey_assist_utils/evaluation/code_comparison.py
+++ b/src/survey_assist_utils/evaluation/code_comparison.py
@@ -1,0 +1,126 @@
+"""Functions to compare clerical codes with model codes."""
+
+from collections.abc import Iterable
+
+INVALID_VALUES = (
+    "-9",
+    "4+",
+    "",
+    ".",
+    " ",
+    None,
+    "NAN",
+    "NaN",
+    "nan",
+    "None",
+    "Null",
+    "<NA>",
+)
+
+
+def compare_codes(
+    clerical_col: str | Iterable[str] | None,
+    model_col: str | Iterable[str] | None,
+    method: str = "MM",
+) -> bool:
+    """Compare clerical and model codes using desired comparison method.
+
+    Args:
+        clerical_col: The clerical code(s) to compare.
+        model_col: The model code(s) to compare.
+        method: The comparison method to use. One of 'OO', 'OM',
+            'MO', 'MM'. Defaults to 'OO'.
+
+    Returns:
+        bool: True if the codes match according to the method, False otherwise.
+
+    Raises:
+        ValueError: If an invalid comparison method is provided.
+    """
+    if method == "OO":
+        return compare_oo(clerical_col, model_col)
+    if method == "OM":
+        return compare_om(clerical_col, model_col)
+    if method == "MO":
+        # invert order of arguments to avoid code duplication
+        return compare_om(clerical_col=model_col, model_col=clerical_col)
+    if method == "MM":
+        return compare_mm(clerical_col, model_col)
+    raise ValueError(f"Invalid comparison method: {method}")
+
+
+def cast_code_to_set(
+    input_data: str | Iterable[str] | None,
+) -> set[str]:
+    """Cast input codes to a set of strings."""
+    if input_data is None:
+        return set()
+    if isinstance(input_data, str) or not isinstance(input_data, Iterable):
+        input_data = {input_data}
+    return {str(x) for x in input_data}.difference(INVALID_VALUES)
+
+
+def cast_code_to_str(
+    input_data: str | Iterable[str] | None,
+) -> str | None:
+    """Cast input codes to a string if unique code is presented.
+
+    Args:
+        input_data: Input data which can be a string, an iterable of strings.
+
+    Returns:
+        A single string if input_data contains exactly one valid code string,
+        None otherwise.
+    """
+    # convert to set to enable len calculation and to remove duplicates
+    input_set = cast_code_to_set(input_data)
+
+    return next(iter(input_set)) if len(input_set) == 1 else None
+
+
+def compare_oo(
+    clerical_col: str | Iterable[str] | None, model_col: str | Iterable[str] | None
+) -> bool:  # pylint: disable=C0103
+    """Returns true where clerical coders and model agree exactly.
+    Assumes cleaned input columns.
+    Applicable to both 2-digit and 5-digit columns.
+    If one is an empty string, returns False.
+    """
+    clerical_col = cast_code_to_str(clerical_col)
+    model_col = cast_code_to_str(model_col)
+
+    if (clerical_col in INVALID_VALUES) or (model_col in INVALID_VALUES):
+        return False
+
+    return clerical_col == model_col
+
+
+def compare_om(
+    clerical_col: str | Iterable[str] | None, model_col: str | Iterable[str] | None
+) -> bool:
+    """Returns true where clerical coder choice is in the model's shortlist.
+    Assumes cleaned input columns.
+    Applicable to both 2-digit and 5-digit columns.
+    If clerical code is an empty string, returns False.
+    If the model's shortlist is empty, returns False.
+    """
+    clerical_col = cast_code_to_str(clerical_col)
+    model_col = cast_code_to_set(model_col)
+    if clerical_col in INVALID_VALUES:
+        return False
+
+    return clerical_col in model_col
+
+
+def compare_mm(
+    clerical_col: str | Iterable[str] | None, model_col: str | Iterable[str] | None
+) -> bool:
+    """Returns true where any clerical coder choice is in the model's shortlist.
+    Assumes cleaned input columns.
+    Applicable to both 2-digit and 5-digit columns.
+    If either list is empty, returns False.
+    """
+    clerical_col = cast_code_to_set(clerical_col)
+    model_col = cast_code_to_set(model_col)
+
+    return bool(clerical_col & model_col)

--- a/src/survey_assist_utils/evaluation/code_comparison.py
+++ b/src/survey_assist_utils/evaluation/code_comparison.py
@@ -18,6 +18,25 @@ INVALID_VALUES = (
 )
 
 
+def cast_code_to_set(
+    input_data: str | Iterable[str] | None,
+) -> set[str]:
+    """Cast input codes to a set of strings.
+
+    Args:
+        input_data: The input code(s) to cast. Can be a single string,
+            an iterable of strings, or None.
+
+    Returns:
+        A set of strings representing the input codes, with invalid values removed.
+    """
+    if input_data is None:
+        return set()
+    if isinstance(input_data, str) or not isinstance(input_data, Iterable):
+        input_data = {input_data}
+    return {str(x) for x in input_data}.difference(INVALID_VALUES)
+
+
 def compare_codes(
     clerical_col: str | Iterable[str] | None,
     model_col: str | Iterable[str] | None,
@@ -37,90 +56,43 @@ def compare_codes(
     Raises:
         ValueError: If an invalid comparison method is provided.
     """
-    if method == "OO":
-        return compare_oo(clerical_col, model_col)
-    if method == "OM":
-        return compare_om(clerical_col, model_col)
-    if method == "MO":
-        # invert order of arguments to avoid code duplication
-        return compare_om(clerical_col=model_col, model_col=clerical_col)
-    if method == "MM":
-        return compare_mm(clerical_col, model_col)
-    raise ValueError(f"Invalid comparison method: {method}")
-
-
-def cast_code_to_set(
-    input_data: str | Iterable[str] | None,
-) -> set[str]:
-    """Cast input codes to a set of strings."""
-    if input_data is None:
-        return set()
-    if isinstance(input_data, str) or not isinstance(input_data, Iterable):
-        input_data = {input_data}
-    return {str(x) for x in input_data}.difference(INVALID_VALUES)
-
-
-def cast_code_to_str(
-    input_data: str | Iterable[str] | None,
-) -> str | None:
-    """Cast input codes to a string if unique code is presented.
-
-    Args:
-        input_data: Input data which can be a string, an iterable of strings.
-
-    Returns:
-        A single string if input_data contains exactly one valid code string,
-        None otherwise.
-    """
-    # convert to set to enable len calculation and to remove duplicates
-    input_set = cast_code_to_set(input_data)
-
-    return next(iter(input_set)) if len(input_set) == 1 else None
-
-
-def compare_oo(
-    clerical_col: str | Iterable[str] | None, model_col: str | Iterable[str] | None
-) -> bool:  # pylint: disable=C0103
-    """Returns true where clerical coders and model agree exactly.
-    Assumes cleaned input columns.
-    Applicable to both 2-digit and 5-digit columns.
-    If one is an empty string, returns False.
-    """
-    clerical_col = cast_code_to_str(clerical_col)
-    model_col = cast_code_to_str(model_col)
-
-    if (clerical_col in INVALID_VALUES) or (model_col in INVALID_VALUES):
-        return False
-
-    return clerical_col == model_col
-
-
-def compare_om(
-    clerical_col: str | Iterable[str] | None, model_col: str | Iterable[str] | None
-) -> bool:
-    """Returns true where clerical coder choice is in the model's shortlist.
-    Assumes cleaned input columns.
-    Applicable to both 2-digit and 5-digit columns.
-    If clerical code is an empty string, returns False.
-    If the model's shortlist is empty, returns False.
-    """
-    clerical_col = cast_code_to_str(clerical_col)
-    model_col = cast_code_to_set(model_col)
-    if clerical_col in INVALID_VALUES:
-        return False
-
-    return clerical_col in model_col
-
-
-def compare_mm(
-    clerical_col: str | Iterable[str] | None, model_col: str | Iterable[str] | None
-) -> bool:
-    """Returns true where any clerical coder choice is in the model's shortlist.
-    Assumes cleaned input columns.
-    Applicable to both 2-digit and 5-digit columns.
-    If either list is empty, returns False.
-    """
     clerical_col = cast_code_to_set(clerical_col)
     model_col = cast_code_to_set(model_col)
 
-    return bool(clerical_col & model_col)
+    return _compare_codes(clerical_col, model_col, method)
+
+
+def _compare_codes(
+    clerical_col: set[str],
+    model_col: set[str],
+    method: str,
+) -> bool:
+    """Compare clerical and model codes using desired comparison method.
+
+    This is a private function that assumes inputs are already cast to sets.
+
+    Args:
+        clerical_col: The clerical code(s) to compare.
+        model_col: The model code(s) to compare.
+        method: The comparison method to use. One of 'OO', 'OM',
+            'MO', 'MM'. Defaults to 'OO'.
+
+    Returns:
+        bool: True if the codes match according to the method, False otherwise.
+
+    Raises:
+        ValueError: If an invalid comparison method is provided.
+    """
+    overlap = bool(clerical_col & model_col)
+    single_clerical = len(clerical_col) == 1
+    single_model = len(model_col) == 1
+
+    if method == "OO":
+        return single_clerical and single_model and overlap
+    if method == "OM":
+        return single_clerical and overlap
+    if method == "MO":
+        return single_model and overlap
+    if method == "MM":
+        return overlap
+    raise ValueError(f"Invalid comparison method: {method}")

--- a/src/survey_assist_utils/evaluation/metrics.py
+++ b/src/survey_assist_utils/evaluation/metrics.py
@@ -1,0 +1,336 @@
+"""Calculation of simple evaluation metrics."""
+
+import logging
+
+import pandas as pd
+from pydantic import BaseModel
+
+from survey_assist_utils.evaluation.code_comparison import (
+    cast_code_to_str,
+    compare_codes,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class AmbiguityMetrics(BaseModel):
+    """Metrics for ambiguity detection: precision, recall, F1-score,
+    and confusion matrix counts.
+    """
+
+    precision: float
+    recall: float
+    f1: float
+    TP: int
+    FP: int
+    FN: int
+    TN: int
+
+    def report_metrics(self):
+        """Pretty print the ambiguity detection metrics."""
+        lines = [
+            "\nAmbiguity decision statistics:",
+            f" F1-score: {100 * self.f1:.2f}%",
+            f" Precision: {100 * self.precision:.2f}%",
+            f" Recall: {100 * self.recall:.2f}%",
+            f" Confusion matrix counts: TP={self.TP}, FP={self.FP}, FN={self.FN}, TN={self.TN}",
+        ]
+        return "\n".join(lines)
+
+
+class AccuracyMetrics(BaseModel):
+    """Metrics for accuracy evaluation: total records, unambiguous records,
+    matches (MM and OO), and accuracy (MM and OO).
+    """
+
+    total_records: int = 0
+    unambiguous_records: int = 0
+    matches_oo: int = 0
+    matches_om: int = 0
+    matches_mo: int = 0
+    matches_mm: int = 0
+    accuracy_oo_total: float = 0.0
+    accuracy_mm_total: float = 0.0
+    accuracy_oo_unambiguous: float = 0.0
+    accuracy_om_unambiguous: float = 0.0
+    accuracy_mo_unambiguous: float = 0.0
+
+    def report_metrics(self, title: str = "Initial"):
+        """Pretty print the accuracy metrics."""
+        lines = [
+            f"\n{title} classification accuracy metrics:",
+            f""" {title} accuracy (OO, subset coded unambiguously by both): {
+                100 * self.accuracy_oo_unambiguous:.2f}% ({self.matches_oo} records)""",
+            f""" {title} accuracy (OM, subset coded unambiguously by clerical): {
+                100 * self.accuracy_om_unambiguous:.2f}% ({self.matches_om} records)""",
+            f""" {title} accuracy (MO, subset coded unambiguously by model): {
+                100 * self.accuracy_mo_unambiguous:.2f}% ({self.matches_mo} records)""",
+            f""" {title} accuracy (MM, full set): {
+                100 * self.accuracy_mm_total:.2f}% ({self.matches_mm} records)""",
+        ]
+        return "\n".join(lines)
+
+
+class CodabilityMetrics(BaseModel):
+    """Metrics for codability: initial and final codable proportions,
+    improvement in codability, and counts of codable records.
+    """
+
+    initial_codable_prop: float
+    final_codable_prop: float | None = None
+    codability_improvement_prop: float | None = None
+    initial_codable_count: int
+    final_codable_count: int | None = None
+
+    def report_metrics(self):
+        """Pretty print the codability metrics."""
+        lines = [
+            "\nCodability metrics:",
+            f""" Initial codability: {
+                100 * self.initial_codable_prop:.2f}% ({self.initial_codable_count} records)""",
+        ]
+        if self.final_codable_prop is not None:
+            lines.append(
+                f""" Final codability: {
+                100 * self.final_codable_prop:.2f}% ({self.final_codable_count} records)"""
+            )
+        if self.codability_improvement_prop is not None:
+            lines.append(
+                f""" Gain in codability: {100 * self.codability_improvement_prop:.2f}pp ({
+                    self.final_codable_count - self.initial_codable_count} records)"""
+            )
+        return "\n".join(lines)
+
+
+class SimpleMetrics(BaseModel):
+    """Container for all simple evaluation metrics."""
+
+    ambiguity_metrics: AmbiguityMetrics
+    codability_metrics: CodabilityMetrics
+    initial_accuracy_metrics: AccuracyMetrics
+    final_accuracy_metrics: AccuracyMetrics | None = None
+
+    def report_metrics(self):
+        """Pretty print all simple metrics."""
+        lines = [
+            "Evaluation metrics summary:",
+            self.ambiguity_metrics.report_metrics(),
+            self.codability_metrics.report_metrics(),
+            self.initial_accuracy_metrics.report_metrics("Initial"),
+        ]
+        if self.final_accuracy_metrics:
+            lines.append(self.final_accuracy_metrics.report_metrics("Final"))
+        return "\n".join(lines)
+
+
+def calc_ambiguity_metrics(
+    df: pd.DataFrame,
+    model_ambiguous_col: str = "initial_ambiguous",
+    truth_ambiguous_col: str = "clerical_ambiguous",
+) -> AmbiguityMetrics:
+    """Calculate ambiguity detection metrics: precision, recall, F1-score.
+
+    Args:
+        df: DataFrame containing model and clerical ambiguity columns.
+        model_ambiguous_col: Column name for model ambiguity predictions (boolean).
+        truth_ambiguous_col: Column name for true (clerical) ambiguity labels (boolean).
+
+    Returns:
+        Dictionary with precision, recall, and F1-score.
+    """
+    true_pos = sum(df[model_ambiguous_col] & df[truth_ambiguous_col])
+    false_pos = sum(df[model_ambiguous_col] & ~df[truth_ambiguous_col])
+    false_neg = sum(~df[model_ambiguous_col] & df[truth_ambiguous_col])
+    true_neg = sum(~df[model_ambiguous_col] & ~df[truth_ambiguous_col])
+
+    precision = 0 if true_pos + false_pos == 0 else true_pos / (true_pos + false_pos)
+    recall = 0 if true_pos + false_neg == 0 else true_pos / (true_pos + false_neg)
+    f1 = (
+        0.0
+        if precision + recall == 0
+        else 2 * (precision * recall) / (precision + recall)
+    )
+
+    return AmbiguityMetrics(
+        precision=precision,
+        recall=recall,
+        f1=f1,
+        TP=true_pos,
+        FP=false_pos,
+        FN=false_neg,
+        TN=true_neg,
+    )
+
+
+def calc_codability_metrics(
+    df: pd.DataFrame,
+    initial_ambiguous_col: str = "initial_ambiguous",
+    final_ambiguous_col: str | None = "final_ambiguous",
+) -> CodabilityMetrics:
+    """Calculate codability metrics: initial and final codable proportions,
+    improvement in codability, and counts of codable records.
+
+    Args:
+        df: DataFrame containing model ambiguity columns.
+        initial_ambiguous_col: Column name for initial model ambiguity predictions (boolean).
+        final_ambiguous_col: Column name for final model ambiguity predictions (boolean).
+
+    Returns:
+        Dictionary with codability metrics.
+    """
+    total_count = len(df)
+    initial_codable_count = sum(~df[initial_ambiguous_col])
+    initial_codable_prop = (
+        initial_codable_count / total_count if total_count > 0 else 0.0
+    )
+
+    if final_ambiguous_col and (final_ambiguous_col in df.columns):
+        final_codable_count = sum(~df[final_ambiguous_col])
+        final_codable_prop = (
+            final_codable_count / total_count if total_count > 0 else 0.0
+        )
+        codability_improvement_prop = (
+            (final_codable_count - initial_codable_count) / total_count
+            if total_count > 0
+            else 0.0
+        )
+    else:
+        final_codable_count = None
+        final_codable_prop = None
+        codability_improvement_prop = None
+
+    return CodabilityMetrics(
+        initial_codable_prop=initial_codable_prop,
+        final_codable_prop=final_codable_prop,
+        codability_improvement_prop=codability_improvement_prop,
+        initial_codable_count=initial_codable_count,
+        final_codable_count=final_codable_count,
+    )
+
+
+def calc_accuracy_metrics(
+    df: pd.DataFrame,
+    model_col: str = "sa_initial_codes",
+    truth_col: str = "clerical_codes",
+) -> AccuracyMetrics:
+    """Calculate classification accuracy metrics.
+
+    Args:
+        df: DataFrame containing model and clerical code columns.
+        model_col: Column name for model predicted codes (string or list/set).
+        truth_col: Column name for true (clerical) codes (string or list/set).
+
+    Returns:
+        Dictionary with accuracy and counts of matches/non-matches.
+    """
+    total = len(df)
+    if total == 0:
+        return AccuracyMetrics()
+
+    def compare_row(row: pd.Series, method) -> bool:
+        return compare_codes(row[truth_col], row[model_col], method=method)
+
+    matches = {}
+    for method in ["OO", "OM", "MO", "MM"]:
+        matches[method] = sum(df.apply(compare_row, method=method, axis=1))
+
+    unambiguous_om = sum(~df[truth_col].apply(lambda x: cast_code_to_str(x) is None))
+    unambiguous_mo = sum(~df[model_col].apply(lambda x: cast_code_to_str(x) is None))
+    unambiguous_oo = sum(
+        (~df[truth_col].apply(lambda x: cast_code_to_str(x) is None))
+        & (~df[model_col].apply(lambda x: cast_code_to_str(x) is None))
+    )
+    accuracy_oo_unambiguous = (
+        matches["OO"] / unambiguous_oo if unambiguous_oo > 0 else 0.0
+    )
+    accuracy_om_unambiguous = (
+        matches["OM"] / unambiguous_om if unambiguous_om > 0 else 0.0
+    )
+    accuracy_mo_unambiguous = (
+        matches["MO"] / unambiguous_mo if unambiguous_mo > 0 else 0.0
+    )
+
+    return AccuracyMetrics(
+        total_records=total,
+        unambiguous_records=unambiguous_oo,
+        matches_mm=matches["MM"],
+        accuracy_mm_total=matches["MM"] / total,
+        matches_oo=matches["OO"],
+        accuracy_oo_total=matches["OO"] / total,
+        accuracy_oo_unambiguous=accuracy_oo_unambiguous,
+        matches_om=matches["OM"],
+        accuracy_om_unambiguous=accuracy_om_unambiguous,
+        matches_mo=matches["MO"],
+        accuracy_mo_unambiguous=accuracy_mo_unambiguous,
+    )
+
+
+def calc_simple_metrics(
+    df: pd.DataFrame,
+    truth_col: str = "clerical_codes",
+    initial_model_col: str = "sa_initial_codes",
+    final_model_col: str | None = "sa_final_codes",
+) -> SimpleMetrics:
+    """Calculate ambiguity detection and classification accuracy metrics.
+
+    Args:
+        df: DataFrame containing model and clerical code columns.
+        truth_col: Column name for true (clerical) codes (string or list/set).
+        initial_model_col: Column name for initial model predicted codes.
+        final_model_col: Column name for final model predicted codes.
+
+    Returns:
+        Dictionary with calculated metrics.
+    """
+    if final_model_col and (final_model_col not in df.columns):
+        logger.warning(
+            "No final classification stats available (final code column not found).",
+        )
+        final_model_col = None
+
+    df = df[
+        [initial_model_col, truth_col] + ([final_model_col] if final_model_col else [])
+    ].copy()
+    df["truth_ambiguous"] = df[truth_col].apply(lambda x: cast_code_to_str(x) is None)
+    df["initial_ambiguous"] = df[initial_model_col].apply(
+        lambda x: cast_code_to_str(x) is None
+    )
+    if final_model_col:
+        df["final_ambiguous"] = df[final_model_col].apply(
+            lambda x: cast_code_to_str(x) is None
+        )
+
+    # Calculate ambiguity metrics
+    ambig_metrics = calc_ambiguity_metrics(
+        df,
+        model_ambiguous_col="initial_ambiguous",
+        truth_ambiguous_col="truth_ambiguous",
+    )
+
+    # Calculate codability metrics
+    codability_metrics = calc_codability_metrics(
+        df,
+        initial_ambiguous_col="initial_ambiguous",
+        final_ambiguous_col="final_ambiguous" if final_model_col else None,
+    )
+
+    # Calculate classification accuracy metrics
+    initial_accuracy_metrics = calc_accuracy_metrics(
+        df, model_col=initial_model_col, truth_col=truth_col
+    )
+
+    if final_model_col:
+        final_accuracy_metrics = calc_accuracy_metrics(
+            df,
+            model_col=final_model_col,
+            truth_col=truth_col,
+        )
+    else:
+        final_accuracy_metrics = None
+
+    return SimpleMetrics(
+        ambiguity_metrics=ambig_metrics,
+        codability_metrics=codability_metrics,
+        initial_accuracy_metrics=initial_accuracy_metrics,
+        final_accuracy_metrics=final_accuracy_metrics,
+    )

--- a/src/survey_assist_utils/evaluation/metrics.py
+++ b/src/survey_assist_utils/evaluation/metrics.py
@@ -6,8 +6,8 @@ import pandas as pd
 from pydantic import BaseModel
 
 from survey_assist_utils.evaluation.code_comparison import (
-    cast_code_to_str,
-    compare_codes,
+    _compare_codes,
+    cast_code_to_set,
 )
 
 logger = logging.getLogger(__name__)
@@ -228,18 +228,18 @@ def calc_accuracy_metrics(
         return AccuracyMetrics()
 
     def compare_row(row: pd.Series, method) -> bool:
-        return compare_codes(row[truth_col], row[model_col], method=method)
+        return _compare_codes(row[truth_col], row[model_col], method=method)
 
     matches = {}
     for method in ["OO", "OM", "MO", "MM"]:
         matches[method] = sum(df.apply(compare_row, method=method, axis=1))
 
-    unambiguous_om = sum(~df[truth_col].apply(lambda x: cast_code_to_str(x) is None))
-    unambiguous_mo = sum(~df[model_col].apply(lambda x: cast_code_to_str(x) is None))
+    unambiguous_om = sum(df[truth_col].apply(len) == 1)
+    unambiguous_mo = sum(df[model_col].apply(len) == 1)
     unambiguous_oo = sum(
-        (~df[truth_col].apply(lambda x: cast_code_to_str(x) is None))
-        & (~df[model_col].apply(lambda x: cast_code_to_str(x) is None))
+        (df[truth_col].apply(len) == 1) & (df[model_col].apply(len) == 1)
     )
+
     accuracy_oo_unambiguous = (
         matches["OO"] / unambiguous_oo if unambiguous_oo > 0 else 0.0
     )
@@ -278,6 +278,7 @@ def calc_simple_metrics(
         truth_col: Column name for true (clerical) codes (string or list/set).
         initial_model_col: Column name for initial model predicted codes.
         final_model_col: Column name for final model predicted codes.
+            Defaults to None (no final accuracy metrics calculated).
 
     Returns:
         Dictionary with calculated metrics.
@@ -288,17 +289,21 @@ def calc_simple_metrics(
         )
         final_model_col = None
 
-    df = df[
-        [initial_model_col, truth_col] + ([final_model_col] if final_model_col else [])
-    ].copy()
-    df["truth_ambiguous"] = df[truth_col].apply(lambda x: cast_code_to_str(x) is None)
-    df["initial_ambiguous"] = df[initial_model_col].apply(
-        lambda x: cast_code_to_str(x) is None
+    required_cols = [initial_model_col, truth_col] + (
+        [final_model_col] if final_model_col else []
     )
+    if miss := set(required_cols) - set(df.columns):
+        raise ValueError(f"DataFrame is missing required columns: {miss}")
+
+    df = df[required_cols].copy()
+    for col in df.columns:
+        df[col] = df[col].apply(cast_code_to_set)
+
+    df["truth_ambiguous"] = df[truth_col].apply(len) != 1
+    df["initial_ambiguous"] = df[initial_model_col].apply(len) != 1
+
     if final_model_col:
-        df["final_ambiguous"] = df[final_model_col].apply(
-            lambda x: cast_code_to_str(x) is None
-        )
+        df["final_ambiguous"] = df[final_model_col].apply(len) != 1
 
     # Calculate ambiguity metrics
     ambig_metrics = calc_ambiguity_metrics(

--- a/tests/evaluation/test_code_comparison.py
+++ b/tests/evaluation/test_code_comparison.py
@@ -1,0 +1,126 @@
+"""Tests for code comparison functions."""
+
+import pytest
+
+from survey_assist_utils.evaluation.code_comparison import (
+    INVALID_VALUES,
+    cast_code_to_set,
+    cast_code_to_str,
+    compare_codes,
+    compare_mm,
+    compare_om,
+    compare_oo,
+)
+
+
+def test_cast_code_to_set():
+    """Test casting various code inputs to set of strings."""
+    assert cast_code_to_set(None) == set(), "None input"
+    assert cast_code_to_set(-9) == set(), "Invalid integer input"
+    assert cast_code_to_set(INVALID_VALUES) == set(), "Invalid values input"
+    assert cast_code_to_set("") == set(), "Empty string input"
+    assert cast_code_to_set("86011") == {"86011"}, "Single valid string input"
+    assert cast_code_to_set(["86011", "86012"]) == {
+        "86011",
+        "86012",
+    }, "List of valid strings"
+    assert cast_code_to_set(["86011", "-9", None, ""]) == {
+        "86011"
+    }, "List with invalid values"
+    assert cast_code_to_set({"86011", "86012"}) == {
+        "86011",
+        "86012",
+    }, "Set of valid strings"
+    assert cast_code_to_set(range(86000, 86003)) == {
+        "86000",
+        "86001",
+        "86002",
+    }, "Iterable of integers"
+
+
+def test_cast_code_to_str():
+    """Test casting various code inputs to a single string."""
+    assert cast_code_to_str(None) is None, "None input"
+    assert cast_code_to_str("") is None, "Empty string input"
+    assert cast_code_to_str(-9) is None, "Invalid integer -9 input"
+    assert cast_code_to_str(42) == "42", "Convert integer input to '42'"
+    assert cast_code_to_str("86011") == "86011", "Single valid string input"
+    assert cast_code_to_str(["86011"]) == "86011", "List with single valid string"
+    assert cast_code_to_str({"86011"}) == "86011", "Set with single valid string"
+    assert cast_code_to_str(["86011", "86012"]) is None, "List with multiple strings"
+    assert cast_code_to_str({"86011", "86012"}) is None, "Set with multiple strings"
+    assert (
+        cast_code_to_str(range(86000, 86003)) is None
+    ), "Iterable with multiple integers"
+
+
+def test_compare_oo_exact_match():
+    """Test the OO comparison method for exact matches."""
+    assert compare_oo("86011", "86011") is True, "OO exact match"
+    assert compare_oo(["86011"], ["86011"]) is True, "OO exact match (list)"
+    assert compare_oo({"86011"}, {"86011"}) is True, "OO exact match (set)"
+    assert compare_oo("86011", "86012") is False, "OO different codes"
+    assert compare_oo(["86011"], ["86012"]) is False, "OO different codes (list)"
+    assert (
+        compare_oo(["86011", "86012"], ["86011"]) is False
+    ), "OO different codes (list)"
+    assert compare_oo("", "86011") is False
+
+
+def test_compare_om_in_shortlist():
+    """Test the OM comparison method for matches in shortlist."""
+    assert compare_om("86011", ["86011", "86012"]) is True, "OM exact match in list"
+    assert compare_om("86012", ["86012"]) is True, "OM exact match in list (single)"
+    assert compare_om("86013", ["86011", "86012"]) is False, "OM no match in list"
+    assert (
+        compare_om(["86011"], ["86011", "86012"]) is True
+    ), "OM exact match in list (single)"
+    assert (
+        compare_om(["86013"], ["86011", "86012"]) is False
+    ), "OM no match in list (single)"
+    assert (
+        compare_om(["86011", "86012"], ["86011", "86012"]) is False
+    ), "OM exact match in list (multiple)"
+    assert compare_om([], ["86011"]) is False, "OM no match in list (empty)"
+
+
+def test_compare_mm_any_in_both():
+    """Test the MM comparison method for any matches in both sets."""
+    assert (
+        compare_mm(["86011", "86012"], ["86012", "86013"]) is True
+    ), "MM overlapping lists"
+    assert compare_mm(["86011", "86012"], ["86013", "86014"]) is False, "MM no overlap"
+    assert compare_mm({"86011"}, "86011") is True, "MM exact match"
+    assert (
+        compare_mm("86011", ["86011", "86012"]) is True
+    ), "MM exact match (single left)"
+    assert (
+        compare_mm(["86011", "86012"], "86012") is True
+    ), "MM exact match (single right)"
+    assert compare_mm([], ["86011"]) is False, "MM no match (empty left)"
+    assert compare_mm(["86011"], None) is False, "MM no match (empty right)"
+    assert (
+        compare_mm("86011", range(86000, 87000)) is True
+    ), "MM exact match (both single)"
+
+
+def test_compare_codes_methods():
+    """Test the main compare_codes function with different methods."""
+    assert compare_codes("86011", ["86011"], method="OO") is True, "OO exact match"
+    assert (
+        compare_codes("86011", ["86011", "86012"], method="OO") is False
+    ), "OO different codes"
+    assert (
+        compare_codes("86011", ["86011", "86012"], method="OM") is True
+    ), "OM exact match in set right"
+    assert (
+        compare_codes(["86011", "86012"], "86011", method="MO") is True
+    ), "MO exact match in set left"
+    assert (
+        compare_codes("86011", ["86011", "86012"], method="MO") is False
+    ), "MO different codes"
+    assert (
+        compare_codes(["86011", "86012"], ["86012", "86013"], method="MM") is True
+    ), "MM overlapping codes"
+    with pytest.raises(ValueError):
+        compare_codes("86011", "86011", method="INVALID")

--- a/tests/evaluation/test_code_comparison.py
+++ b/tests/evaluation/test_code_comparison.py
@@ -5,11 +5,7 @@ import pytest
 from survey_assist_utils.evaluation.code_comparison import (
     INVALID_VALUES,
     cast_code_to_set,
-    cast_code_to_str,
     compare_codes,
-    compare_mm,
-    compare_om,
-    compare_oo,
 )
 
 
@@ -38,89 +34,103 @@ def test_cast_code_to_set():
     }, "Iterable of integers"
 
 
-def test_cast_code_to_str():
-    """Test casting various code inputs to a single string."""
-    assert cast_code_to_str(None) is None, "None input"
-    assert cast_code_to_str("") is None, "Empty string input"
-    assert cast_code_to_str(-9) is None, "Invalid integer -9 input"
-    assert cast_code_to_str(42) == "42", "Convert integer input to '42'"
-    assert cast_code_to_str("86011") == "86011", "Single valid string input"
-    assert cast_code_to_str(["86011"]) == "86011", "List with single valid string"
-    assert cast_code_to_str({"86011"}) == "86011", "Set with single valid string"
-    assert cast_code_to_str(["86011", "86012"]) is None, "List with multiple strings"
-    assert cast_code_to_str({"86011", "86012"}) is None, "Set with multiple strings"
-    assert (
-        cast_code_to_str(range(86000, 86003)) is None
-    ), "Iterable with multiple integers"
-
-
 def test_compare_oo_exact_match():
     """Test the OO comparison method for exact matches."""
-    assert compare_oo("86011", "86011") is True, "OO exact match"
-    assert compare_oo(["86011"], ["86011"]) is True, "OO exact match (list)"
-    assert compare_oo({"86011"}, {"86011"}) is True, "OO exact match (set)"
-    assert compare_oo("86011", "86012") is False, "OO different codes"
-    assert compare_oo(["86011"], ["86012"]) is False, "OO different codes (list)"
+    assert compare_codes("86011", "86011", method="OO") is True, "OO exact match"
+    assert compare_codes(86011, ["86011"], method="OO") is True, "OO exact match (int)"
     assert (
-        compare_oo(["86011", "86012"], ["86011"]) is False
+        compare_codes(["86011"], ["86011"], method="OO") is True
+    ), "OO exact match (list)"
+    assert (
+        compare_codes({"86011"}, {"86011"}, method="OO") is True
+    ), "OO exact match (set)"
+    assert compare_codes("86011", "86012", method="OO") is False, "OO different codes"
+    assert (
+        compare_codes(["86011"], ["86012"], method="OO") is False
     ), "OO different codes (list)"
-    assert compare_oo("", "86011") is False
+    assert (
+        compare_codes(["86011", "86012"], ["86011"], method="OO") is False
+    ), "OO different codes (list)"
+    assert compare_codes("", "86011", method="OO") is False
 
 
 def test_compare_om_in_shortlist():
     """Test the OM comparison method for matches in shortlist."""
-    assert compare_om("86011", ["86011", "86012"]) is True, "OM exact match in list"
-    assert compare_om("86012", ["86012"]) is True, "OM exact match in list (single)"
-    assert compare_om("86013", ["86011", "86012"]) is False, "OM no match in list"
     assert (
-        compare_om(["86011"], ["86011", "86012"]) is True
+        compare_codes("86011", ["86011", "86012"], method="OM") is True
+    ), "OM exact match in list"
+    assert (
+        compare_codes("86012", ["86012"], method="OM") is True
     ), "OM exact match in list (single)"
     assert (
-        compare_om(["86013"], ["86011", "86012"]) is False
+        compare_codes("86013", ["86011", "86012"], method="OM") is False
+    ), "OM no match in list"
+    assert (
+        compare_codes(["86011"], ["86011", "86012"], method="OM") is True
+    ), "OM exact match in list (single)"
+    assert (
+        compare_codes(["86013"], ["86011", "86012"], method="OM") is False
     ), "OM no match in list (single)"
     assert (
-        compare_om(["86011", "86012"], ["86011", "86012"]) is False
+        compare_codes(["86011", "86012"], ["86011", "86012"], method="OM") is False
     ), "OM exact match in list (multiple)"
-    assert compare_om([], ["86011"]) is False, "OM no match in list (empty)"
+    assert (
+        compare_codes([], ["86011"], method="OM") is False
+    ), "OM no match in list (empty)"
+
+
+def test_compare_mo_in_shortlist():
+    """Test the MO comparison method for matches in shortlist."""
+    assert (
+        compare_codes(["86011", "86012"], "86011", method="MO") is True
+    ), "MO exact match in list"
+    assert (
+        compare_codes(["86012"], "86012", method="MO") is True
+    ), "MO exact match in list (single)"
+    assert (
+        compare_codes(["86013"], "86011", method="MO") is False
+    ), "MO no match in list"
+    assert (
+        compare_codes(["86011", "86012"], ["86011"], method="MO") is True
+    ), "MO exact match in list (single)"
+    assert (
+        compare_codes(["86011", "86012"], ["86013"], method="MO") is False
+    ), "MO no match in list (single)"
+    assert (
+        compare_codes(["86011", "86012"], ["86011", "86012"], method="MO") is False
+    ), "MO exact match in list (multiple)"
+    assert (
+        compare_codes(["86011"], [], method="MO") is False
+    ), "MO no match in list (empty)"
 
 
 def test_compare_mm_any_in_both():
     """Test the MM comparison method for any matches in both sets."""
     assert (
-        compare_mm(["86011", "86012"], ["86012", "86013"]) is True
+        compare_codes(["86011", "86012"], ["86012", "86013"], method="MM") is True
     ), "MM overlapping lists"
-    assert compare_mm(["86011", "86012"], ["86013", "86014"]) is False, "MM no overlap"
-    assert compare_mm({"86011"}, "86011") is True, "MM exact match"
     assert (
-        compare_mm("86011", ["86011", "86012"]) is True
+        compare_codes(["86011", "86012"], ["86013", "86014"], method="MM") is False
+    ), "MM no overlap"
+    assert compare_codes({"86011"}, "86011", method="MM") is True, "MM exact match"
+    assert (
+        compare_codes("86011", ["86011", "86012"], method="MM") is True
     ), "MM exact match (single left)"
     assert (
-        compare_mm(["86011", "86012"], "86012") is True
+        compare_codes(["86011", "86012"], "86012", method="MM") is True
     ), "MM exact match (single right)"
-    assert compare_mm([], ["86011"]) is False, "MM no match (empty left)"
-    assert compare_mm(["86011"], None) is False, "MM no match (empty right)"
     assert (
-        compare_mm("86011", range(86000, 87000)) is True
+        compare_codes([], ["86011"], method="MM") is False
+    ), "MM no match (empty left)"
+    assert (
+        compare_codes(["86011"], None, method="MM") is False
+    ), "MM no match (empty right)"
+    assert (
+        compare_codes("86011", range(86000, 87000), method="MM") is True
     ), "MM exact match (both single)"
 
 
-def test_compare_codes_methods():
-    """Test the main compare_codes function with different methods."""
-    assert compare_codes("86011", ["86011"], method="OO") is True, "OO exact match"
-    assert (
-        compare_codes("86011", ["86011", "86012"], method="OO") is False
-    ), "OO different codes"
-    assert (
-        compare_codes("86011", ["86011", "86012"], method="OM") is True
-    ), "OM exact match in set right"
-    assert (
-        compare_codes(["86011", "86012"], "86011", method="MO") is True
-    ), "MO exact match in set left"
-    assert (
-        compare_codes("86011", ["86011", "86012"], method="MO") is False
-    ), "MO different codes"
-    assert (
-        compare_codes(["86011", "86012"], ["86012", "86013"], method="MM") is True
-    ), "MM overlapping codes"
+def test_compare_codes_invalid_method():
+    """Test the main compare_codes function with invalid methods."""
     with pytest.raises(ValueError):
         compare_codes("86011", "86011", method="INVALID")

--- a/tests/evaluation/test_metrics.py
+++ b/tests/evaluation/test_metrics.py
@@ -57,8 +57,8 @@ def test_calc_accuracy_metrics_basic():
     """Basic test for accuracy metrics calculation."""
     df = pd.DataFrame(
         {
-            "sa_initial_codes": [["A"], ["B", "C"], ["C"], ["D"]],
-            "clerical_codes": [["A"], ["B"], ["C"], ["E"]],
+            "sa_initial_codes": [{"A"}, {"B", "C"}, {"C"}, {"D"}],
+            "clerical_codes": [{"A"}, {"B"}, {"C"}, {"E"}],
         }
     )
     accuracy_metrics = calc_accuracy_metrics(df)
@@ -73,8 +73,8 @@ def test_calc_simple_metrics_basic():
     """Basic test for simple metrics calculation."""
     df = pd.DataFrame(
         {
-            "clerical_codes": ["A", "B", "-9", "E"],
-            "sa_initial_codes": ["A", ["B", "C"], None, "D"],
+            "clerical_codes": ["A", "B", -9, "E"],
+            "sa_initial_codes": ["A", ["B", "C"], None, {"D"}],
             "sa_final_codes": [["A"], ["B"], ["C"], ["D"]],
         }
     )

--- a/tests/evaluation/test_metrics.py
+++ b/tests/evaluation/test_metrics.py
@@ -1,0 +1,95 @@
+"""Tests for evaluation metrics calculations."""
+
+import pandas as pd
+import pytest
+
+from survey_assist_utils.evaluation.metrics import (
+    calc_accuracy_metrics,
+    calc_ambiguity_metrics,
+    calc_codability_metrics,
+    calc_simple_metrics,
+)
+
+
+def test_calc_ambiguity_metrics_basic():
+    """Basic test for ambiguity metrics calculation."""
+    df = pd.DataFrame(
+        {
+            "initial_ambiguous": [True, False, True, False],
+            "clerical_ambiguous": [True, True, False, False],
+        }
+    )
+    ambiguity_metrics = calc_ambiguity_metrics(df)
+    assert ambiguity_metrics.TP == 1
+    assert ambiguity_metrics.FP == 1
+    assert ambiguity_metrics.FN == 1
+    assert ambiguity_metrics.TN == 1
+    assert ambiguity_metrics.precision == pytest.approx(0.5)
+    assert ambiguity_metrics.recall == pytest.approx(0.5)
+    assert ambiguity_metrics.f1 == pytest.approx(0.5)
+
+
+def test_calc_codability_metrics_basic():
+    """Basic test for codability metrics calculation."""
+    df = pd.DataFrame(
+        {
+            "initial_ambiguous": [True, False, True, False],
+            "final_ambiguous": [True, False, False, False],
+        }
+    )
+    codability_metrics = calc_codability_metrics(df)
+    assert (
+        codability_metrics.initial_codable_count
+        < codability_metrics.final_codable_count
+    )
+    assert codability_metrics.initial_codable_prop == pytest.approx(
+        0.5
+    ), "Initial codable proportion mismatch"
+    assert codability_metrics.final_codable_prop == pytest.approx(
+        0.75
+    ), "Final codable proportion mismatch"
+    assert codability_metrics.codability_improvement_prop == pytest.approx(
+        0.25
+    ), "Codability improvement proportion mismatch"
+
+
+def test_calc_accuracy_metrics_basic():
+    """Basic test for accuracy metrics calculation."""
+    df = pd.DataFrame(
+        {
+            "sa_initial_codes": [["A"], ["B", "C"], ["C"], ["D"]],
+            "clerical_codes": [["A"], ["B"], ["C"], ["E"]],
+        }
+    )
+    accuracy_metrics = calc_accuracy_metrics(df)
+    assert accuracy_metrics.total_records == df.shape[0]
+    assert accuracy_metrics.matches_oo == df.shape[0] / 2
+    assert accuracy_metrics.matches_mm == df.shape[0] - 1
+    assert accuracy_metrics.accuracy_oo_total == pytest.approx(0.5)
+    assert accuracy_metrics.accuracy_mm_total == pytest.approx(0.75)
+
+
+def test_calc_simple_metrics_basic():
+    """Basic test for simple metrics calculation."""
+    df = pd.DataFrame(
+        {
+            "clerical_codes": ["A", "B", "-9", "E"],
+            "sa_initial_codes": ["A", ["B", "C"], None, "D"],
+            "sa_final_codes": [["A"], ["B"], ["C"], ["D"]],
+        }
+    )
+    simple_metrics = calc_simple_metrics(df)
+
+    assert simple_metrics.ambiguity_metrics.f1 == pytest.approx(2 / 3)
+    assert (
+        simple_metrics.codability_metrics.codability_improvement_prop
+        == pytest.approx(0.5)
+    )
+    assert (
+        simple_metrics.initial_accuracy_metrics.accuracy_mo_unambiguous
+        == pytest.approx(0.5)
+    )
+    assert (
+        simple_metrics.final_accuracy_metrics.accuracy_om_unambiguous
+        == pytest.approx(2 / 3)
+    )


### PR DESCRIPTION
## ✨ Summary

Helper functions for comparing codes and report metrics

## 📜 Changes Introduced

- helper functions `compare_oo/om/mo/mm` brought from eval script to src
- metrics reporting wrapped into 3 building blocks:
  - ambiguity (f1, precision, recall and confusion metrics)
  - codability change from initial codes to final codes
  - accuracy (by oo/mo/om/mm type on corresponding subset)
- unit tests included

## ✅ Checklist

> **Please confirm you've completed these checks before requesting a review.**

- [x] Code is formatted using **Black**
- [x] Imports are sorted using **isort**
- [x] Code passes linting with **Ruff**, **Pylint**, and **Mypy**
- [x] Security checks pass using **Bandit**
- [x] API and Unit tests are written and pass using **pytest**
- [ ] Terraform files (if applicable) follow best practices and have been validated (`terraform fmt` & `terraform validate`)
- [x] DocStrings follow Google-style and are added as per Pylint recommendations
- [ ] Documentation has been updated if needed

## 🔍 How to Test

documenrtation and end-to-end example included in draft PR #26 
